### PR TITLE
Support timezone pattern option

### DIFF
--- a/generators/src/main/scala/io/gen4s/generators/impl/DatetimeGenerator.scala
+++ b/generators/src/main/scala/io/gen4s/generators/impl/DatetimeGenerator.scala
@@ -4,7 +4,7 @@ package impl
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 import io.circe.derivation.ConfiguredCodec
 import io.gen4s.core.generators.*
@@ -22,7 +22,7 @@ final case class DatetimeGenerator(
   private val defaultFormat: String = "MM/dd/yyyy"
 
   override def gen(): GeneratedValue = {
-    val dt = LocalDateTime
+    val dt = ZonedDateTime
       .now()
       .plus(shiftSeconds.getOrElse(0L), ChronoUnit.SECONDS)
       .plus(shiftDays.getOrElse(0L), ChronoUnit.DAYS)


### PR DESCRIPTION
This change allows to define a pattern with timezone for date field

```json
{ "variable": "date", "type": "date", "format": "dd/MMM/yyyy HH:mm:ss Z"},
```